### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -1,12 +1,12 @@
-BubbleBackpack KEYWORD1
+BubbleBackpack	KEYWORD1
 
-setupDisplay KEYWORD2
-clearDisplay KEYWORD2
-setDisplayIntensity KEYWORD2
-writeDigit KEYWORD2
-writeSegment KEYWORD2
-quickTest KEYWORD2
-readFromSerial KEYWORD2
-numofDisplays KEYWORD2
-numOfDigits KEYWORD2
-spiTransfer KEYWORD2
+setupDisplay	KEYWORD2
+clearDisplay	KEYWORD2
+setDisplayIntensity	KEYWORD2
+writeDigit	KEYWORD2
+writeSegment	KEYWORD2
+quickTest	KEYWORD2
+readFromSerial	KEYWORD2
+numofDisplays	KEYWORD2
+numOfDigits	KEYWORD2
+spiTransfer	KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords